### PR TITLE
[Refactor] Updates to rakelib dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,18 @@
-require "rake/testtask"
+# -----------------------------------------------
+#                     Tests
+# -----------------------------------------------
+
+require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
+
+# -----------------------------------------------
+#                    Console
+# -----------------------------------------------
 
 desc "Open an irb console"
 task :console do

--- a/rakelib/constants.rb
+++ b/rakelib/constants.rb
@@ -1,13 +1,3 @@
+SILENT                  = true
 FLAMEGRAPH_GEMSPEC_FILE = File.expand_path File.join(*%w[.. .. flamegraph-ruby.gemspec]), __FILE__
 FLAMEGRAPH_GEMSPEC      = eval File.read(FLAMEGRAPH_GEMSPEC_FILE)
-
-def sh_opts
-  [
-    { [:out, :err] => File::NULL, },
-    { :verbose     => false }
-  ]
-end
-
-def run cmd, *args
-  sh cmd, *args, *sh_opts
-end

--- a/rakelib/constants.rb
+++ b/rakelib/constants.rb
@@ -1,3 +1,0 @@
-SILENT                  = true
-FLAMEGRAPH_GEMSPEC_FILE = File.expand_path File.join(*%w[.. .. flamegraph-ruby.gemspec]), __FILE__
-FLAMEGRAPH_GEMSPEC      = eval File.read(FLAMEGRAPH_GEMSPEC_FILE)

--- a/rakelib/rubygems_build.rake
+++ b/rakelib/rubygems_build.rake
@@ -1,5 +1,8 @@
-require "rubygems/package_task"
-require File.expand_path "constants", File.dirname(__FILE__)
+rakelib = File.expand_path "..", __FILE__
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require 'rubygems/package_task'
+require 'constants'
 
 namespace :rubygems do
   Gem::PackageTask.new(FLAMEGRAPH_GEMSPEC).define

--- a/rakelib/rubygems_build.rake
+++ b/rakelib/rubygems_build.rake
@@ -2,7 +2,7 @@ rakelib = File.expand_path "..", __FILE__
 $LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
 
 require 'rubygems/package_task'
-require 'constants'
+require 'support/rake_constants'
 
 namespace :rubygems do
   Gem::PackageTask.new(FLAMEGRAPH_GEMSPEC).define

--- a/rakelib/support/rake_constants.rb
+++ b/rakelib/support/rake_constants.rb
@@ -1,0 +1,5 @@
+relative_gemspec_path   = File.join *%w[.. .. .. flamegraph-ruby.gemspec]
+
+SILENT                  = true
+FLAMEGRAPH_GEMSPEC_FILE = File.expand_path relative_gemspec_path, __FILE__
+FLAMEGRAPH_GEMSPEC      = eval File.read(FLAMEGRAPH_GEMSPEC_FILE)

--- a/rakelib/support/shell_helper.rb
+++ b/rakelib/support/shell_helper.rb
@@ -1,0 +1,62 @@
+# == Shell Helper
+#
+# An augment module of the `rake`'s FileUtils patch of `sh`.  Can be included
+# by including in a Rakefile or Class/Module by doing:
+#
+#   require 'rake/fileutils'
+#   require 'support/shell_helper'
+#
+#   include FileUtils
+#   include ShellHelper
+#
+# This makes the `run` method accessible for the given context.
+#
+module ShellHelper
+
+  module_function
+
+  # :call-seq:
+  #   run cmd, *args
+  #   run cmd, *args, &block
+  #   run cmd, *args, silent &block
+  #   run cmd, *args, output_io &block
+  #   run cmd, *args, output_io, silent &block
+  #
+  # Runs a `cmd` and it's `args` using `.system`
+  #
+  # This is a wrapper around rake's own `sh` method, with the output suppressed
+  # by default, and the command being run echo'ed to STDOUT.
+  #
+  # If a block is passed, it includes a `true`/`false` "ok" argument and a
+  # `exitcode` as block variables that can react to the command in a customized
+  # fashion.
+  #
+  # If `silent` is passed as boolean (or the SILENT contsant), then the command
+  # is not echo'd to the terminal.
+  #
+  # If `output_io` is passed and is a IO-like object, then the output is saved
+  # into the terminal, and is then returned as the result when the method is
+  # completed.  Otherwise `nil` will be returned.
+  #
+  def run cmd, *args, &block
+    silent = args.pop if [true, false, nil].include? args.last
+    output = args.pop if args.last.class <= IO
+
+    puts ">>>>> #{cmd} #{args.join(' ')}" unless silent
+
+    sh cmd, *args, *sh_opts(output), &block
+
+    output
+  ensure
+    output.rewind if output
+  end
+
+  def sh_opts output = nil
+    output ||= File::NULL
+    [
+      { [:out, :err] => output },
+      { :verbose     => false  }
+    ]
+  end
+  private_class_method :sh_opts
+end

--- a/rakelib/vendorize.rake
+++ b/rakelib/vendorize.rake
@@ -15,4 +15,9 @@ namespace :vendorize do
 
     Vendorize.as_exe
   end
+
+  task :all => [:lib, :exe]
 end
+
+desc 'Create all "vendorized" files'
+task :vendorize => "vendorize:all"

--- a/rakelib/vendorize.rake
+++ b/rakelib/vendorize.rake
@@ -3,14 +3,14 @@ $LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
 
 namespace :vendorize do
   desc 'Create a singlefile library for flamegraph-ruby'
-  task :lib do
+  task :lib => "pkg" do
     require 'support/vendorize'
 
     Vendorize.as_lib
   end
 
   desc 'Create a singlefile executable for flamegraph-ruby'
-  task :exe do
+  task :exe => "pkg" do
     require 'support/vendorize'
 
     Vendorize.as_exe

--- a/rakelib/vendorize.rake
+++ b/rakelib/vendorize.rake
@@ -1,14 +1,17 @@
+rakelib = File.expand_path "..", __FILE__
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
 namespace :vendorize do
   desc 'Create a singlefile library for flamegraph-ruby'
   task :lib do
-    require File.expand_path File.join('..', 'support', 'vendorize'), __FILE__
+    require 'support/vendorize'
 
     Vendorize.as_lib
   end
 
   desc 'Create a singlefile executable for flamegraph-ruby'
   task :exe do
-    require File.expand_path File.join('..', 'support', 'vendorize'), __FILE__
+    require 'support/vendorize'
 
     Vendorize.as_exe
   end


### PR DESCRIPTION
- Use `$LOAD_PATH` to simplify requires
- Add some section headers for `Rakefile`
- Create `ShellHelper` helper module
- Move `rakelib/constants.rb` into `rakelib/support/rake_constants.rb`
- Updates to `vendorize.rake` (extra tasks, ensuring `pkg/` dir)