### PR TITLE
Gem Release tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+Changelog
+=========
+
+
+v0.1.0
+------
+
+- Initial commit, with (close to) feature parity with the original `perl`
+  project ( https://github.com/brendangregg/FlameGraph )
+- Add Release tasks
+- Add CHANGELOG.md
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,8 @@
+rakelib = File.expand_path "rakelib", File.dirname(__FILE__)
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require "support/rake_constants"
+
 # -----------------------------------------------
 #                     Tests
 # -----------------------------------------------
@@ -25,5 +30,15 @@ task :console do
 
   TOPLEVEL_BINDING.irb
 end
+
+# -----------------------------------------------
+#                    Release
+# -----------------------------------------------
+
+desc "Release #{FLAMEGRAPH_GEM_NAME}"
+task :release         => ["git:tag", "git:validate", "github:release"]
+
+desc "Release #{FLAMEGRAPH_GEM_NAME} manually (without Github Actions)"
+task "release:manual" => [:release, "rubygems:push", "github:push"]
 
 task :default => :test

--- a/rakelib/git.rake
+++ b/rakelib/git.rake
@@ -1,0 +1,133 @@
+rakelib = File.expand_path "..", __FILE__
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require 'rake'
+require 'rake/tasklib'
+require 'tmpdir'
+
+require 'support/rake_constants'
+require 'support/shell_helper'
+
+class GitError < StandardError
+  def initialize cmd, output
+    msg = generate_message cmd, output
+    super msg
+  end
+
+  private
+
+  def generate_message command, output
+    output.rewind if output.respond_to? :rewind
+
+    out = output
+    out = output.string if output.kind_of? StringIO
+    out = output.read   if output.kind_of? IO
+    cmd = command
+    cmd = cmd.join(" ") if command.kind_of? Array
+
+    "`#{cmd}' failed with the following output:\n\n#{out}\n"
+  end
+end
+
+module Git
+  SILENT = true
+
+  extend FileUtils
+  extend ShellHelper
+
+  module_function
+
+  def tag tag, msg
+    git_tags       = run "git", "tag", git_output_dir.join("git-tags").open("w+"), SILENT
+    already_tagged = git_tags.read.split("\n").include?(FLAMEGRAPH_VERSION_TAG)
+
+    unless already_tagged
+      begin
+        git "tag", "-m", msg, tag
+        git "push"
+        git "push", "--tags"
+      rescue => e
+        puts "Un-tagging due to error..."
+        run "git", "tag", "-d", version_tag, SILENT
+        raise e
+      end
+    end
+
+  end
+
+  # Ensure there isn't an dirty index
+  def clean?
+    git "diff", "--exit-code", SILENT do |ok, _|
+      fail "Git: index is not clean!" unless ok
+    end
+  end
+
+  # Ensure there are no files staged for a commit
+  def commited?
+    git "diff-index", "--quiet", "--cached", "HEAD", SILENT do |ok, _|
+      fail "Git: some changes are not committed!" unless ok
+    end
+  end
+
+  # Ensure we are on the right tag
+  def on_current_release_tag? expected_version_tag
+    git "describe", SILENT do |ok, _, tag_check_out|
+      tag_check_out.rewind
+      current_tag = tag_check_out.readlines.first.chomp
+
+      if !ok or current_tag != expected_version_tag
+        fail "Git: not on the proper tag!"
+      end
+    end
+  end
+
+  def git *git_args, &block
+    silent          = git_args.pop if [true, false, nil].include? git_args.last
+    git_cmd         = ["git"] + git_args
+    output_filename = git_cmd.join(" ").gsub(/[^a-zA-Z0-9 ]/, '').tr(' ', '-')
+    cmd_output      = git_output_dir.join(output_filename).open "w+"
+
+    if block_given?
+      wrapper_block = lambda { |ok, _| block.call ok, git_cmd, cmd_output }
+      run *git_cmd, cmd_output, silent, &wrapper_block
+    else
+      run *git_cmd, cmd_output, silent do |ok, _|
+        raise GitError.new(git_cmd, cmd_output) unless ok
+      end
+    end
+  end
+  private_class_method :git
+
+  def git_output_dir
+    require 'pathname'
+    @git_output_dir ||= Pathname.new git_tmpdir
+  end
+  private_class_method :git_output_dir
+
+  def git_tmpdir
+    @git_tmpdir ||= Dir.mktmpdir
+  end
+end
+
+at_exit { FileUtils.rm_rf Git.git_tmpdir }
+
+namespace :git do
+  task :clean do
+    Git.clean?
+  end
+
+  task :committed do
+    Git.commited?
+  end
+
+  task :validate_tag do
+    Git.on_current_release_tag? FLAMEGRAPH_VERSION_TAG
+  end
+
+  task :ok       => [:clean, :committed]
+  task :validate => [:ok, :validate_tag]
+
+  task :tag => [:ok] do
+    Git.tag FLAMEGRAPH_VERSION_TAG, %Q{"Version #{FLAMEGRAPH_GEMSPEC.version}"}
+  end
+end

--- a/rakelib/github.rake
+++ b/rakelib/github.rake
@@ -1,0 +1,12 @@
+rakelib = File.expand_path "..", __FILE__
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require "support/changelog_helper"
+require "support/github_api_helper"
+
+namespace :github do
+  desc "Create a release on github.com for NickLaMuro/FlameGraph-ruby"
+  task :release => %w[git:tag git:validate] do
+    GitHubAPI.create_release
+  end
+end

--- a/rakelib/github_build.rake
+++ b/rakelib/github_build.rake
@@ -1,0 +1,24 @@
+rakelib = File.expand_path "..", __FILE__
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require "support/rake_constants"
+require 'support/rubygems_helper'
+
+include RubygemsHelper
+
+namespace :github do
+  task :credentials do
+    write_gem_credentials :github => ENV["GEM_HOST_API_KEY"] unless ENV["GEM_HOST_API_KEY"]
+  end
+
+  task :package => "rubygems:package"
+
+  desc "Push #{FLAMEGRAPH_GEM_NAME} to rubygems.pkg.github.com"
+  task :push => [:credentials, :package] do
+    package = File.join "pkg", FLAMEGRAPH_GEM_NAME.full_name
+
+    gem_run "--key",  "github",
+            "--host", "https://rubygems.pkg.github.com/NickLaMuro",
+            "push",   package
+  end
+end

--- a/rakelib/rubygems_build.rake
+++ b/rakelib/rubygems_build.rake
@@ -29,4 +29,14 @@ namespace :rubygems do
 
   desc "Repackage, Uninstall and Install"
   task :reinstall => [:repackage, :uninstall, :install]
+
+  task :credentials do
+    write_gem_credentials
+  end
+
+  desc "Push #{FLAMEGRAPH_GEM_NAME} to rubygems.org"
+  task :push => [:credentials, :package] do
+    package = File.join "pkg", FLAMEGRAPH_GEM_NAME
+    gem_run "push", package
+  end
 end

--- a/rakelib/rubygems_build.rake
+++ b/rakelib/rubygems_build.rake
@@ -3,16 +3,12 @@ $LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
 
 require 'rubygems/package_task'
 require 'support/rake_constants'
+require 'support/rubygems_helper'
+
+include RubygemsHelper
 
 namespace :rubygems do
   Gem::PackageTask.new(FLAMEGRAPH_GEMSPEC).define
-
-  def gem_run *args
-    require "rubygems/gem_runner"
-    require "rubygems/exceptions"
-
-    Gem::GemRunner.new.run args
-  end
 
   desc "Install the build of the gem locally"
   task :install => [:package] do

--- a/rakelib/support/changelog_helper.rb
+++ b/rakelib/support/changelog_helper.rb
@@ -1,0 +1,26 @@
+rakelib = File.expand_path "..", File.dirname(__FILE__)
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require "support/rake_constants"
+
+module Changelog
+  VERSION_HEADER_MATCH = /^(v(?:\d+\.){2}\d+[\-0-9a-zA-Z]*)$/
+
+  module_function
+
+  # Capture the CHANGELOG.md for this version only
+  def release_desc
+    return @release_desc if defined? @release_desc
+
+    release_info = []
+
+    File.foreach "CHANGELOG.md" do |line|
+      version_header = line.match ::Changelog::VERSION_HEADER_MATCH
+      break if version_header && version_header[1] != FLAMEGRAPH_VERSION_TAG
+
+      release_info << line
+    end
+
+    @release_desc = release_info.join
+  end
+end

--- a/rakelib/support/github_api_helper.rb
+++ b/rakelib/support/github_api_helper.rb
@@ -1,0 +1,55 @@
+rakelib = File.expand_path "..", File.dirname(__FILE__)
+$LOAD_PATH.unshift(rakelib) unless $LOAD_PATH.include?(rakelib)
+
+require "support/rake_constants"
+
+module GitHubAPI
+  module_function
+
+  def create_release
+    post_data = {
+      "tag_name"         => FLAMEGRAPH_VERSION_TAG,
+      "name"             => FLAMEGRAPH_VERSION_TAG,
+      "body"             => Changelog.release_desc,
+      "draft"            => false,
+      "prerelease"       => false
+    }
+
+    uri  = URI('https://api.github.com/repos/NickLaMuro/FlameGraph-ruby/releases')
+    post = Net::HTTP::Post.new(uri)
+    post['Authorization'] = "token #{github_auth['oauth_token']}"
+
+    github_api.request post, post_data.to_json
+  end
+
+  def github_api
+    return @github_api if defined? @github_api
+
+    require 'net/http'
+
+    github_ui   = URI('https://api.github.com/')
+    @github_api = Net::HTTP.new(github_ui.host, github_ui.port)
+  end
+  private_class_method :github_api
+
+  def github_auth
+    return @github_auth if defined? @github_auth
+
+    hub_creds_file = File.join Dir.home, ".config", "hub"
+    unless File.exist? hub_creds_file
+      fail "No Hub Credentials set!  Configure github auth in '#{hub_creds_file}'"
+    end
+
+    require 'yaml'
+
+    hub_conf  = YAML.load_file hub_creds
+    hub_creds = hub_conf["github.com"].detect { |auth| auth['user'] == "NickLaMuro" }
+
+    unless hub_creds['oauth_token']
+      fail "GitHub Auth token NOT FOUND!  Configure github auth in '#{hub_creds_file}'"
+    end
+
+    @github_auth = hub_creds['oauth_token']
+  end
+  private_class_method :github_auth
+end

--- a/rakelib/support/github_api_helper.rb
+++ b/rakelib/support/github_api_helper.rb
@@ -11,7 +11,7 @@ module GitHubAPI
       "tag_name"         => FLAMEGRAPH_VERSION_TAG,
       "name"             => FLAMEGRAPH_VERSION_TAG,
       "body"             => Changelog.release_desc,
-      "draft"            => false,
+      "draft"            => true,
       "prerelease"       => false
     }
 

--- a/rakelib/support/rake_constants.rb
+++ b/rakelib/support/rake_constants.rb
@@ -3,3 +3,4 @@ relative_gemspec_path   = File.join *%w[.. .. .. flamegraph-ruby.gemspec]
 SILENT                  = true
 FLAMEGRAPH_GEMSPEC_FILE = File.expand_path relative_gemspec_path, __FILE__
 FLAMEGRAPH_GEMSPEC      = eval File.read(FLAMEGRAPH_GEMSPEC_FILE)
+FLAMEGRAPH_VERSION_TAG  = "v#{FLAMEGRAPH_GEMSPEC.version}"

--- a/rakelib/support/rake_constants.rb
+++ b/rakelib/support/rake_constants.rb
@@ -4,3 +4,4 @@ SILENT                  = true
 FLAMEGRAPH_GEMSPEC_FILE = File.expand_path relative_gemspec_path, __FILE__
 FLAMEGRAPH_GEMSPEC      = eval File.read(FLAMEGRAPH_GEMSPEC_FILE)
 FLAMEGRAPH_VERSION_TAG  = "v#{FLAMEGRAPH_GEMSPEC.version}"
+FLAMEGRAPH_GEM_NAME     = FLAMEGRAPH_GEMSPEC.full_name

--- a/rakelib/support/rubygems_helper.rb
+++ b/rakelib/support/rubygems_helper.rb
@@ -9,4 +9,19 @@ module RubygemsHelper
 
     Gem::GemRunner.new.run args
   end
+
+  # Create a gem_credentials file if the GEM_HOST_API_KEY ENV var is set
+  def gem_credentials creds = nil
+    if ENV["GEM_HOST_API_KEY"]
+      require 'yaml'
+
+      creds ||= { :rubygems_api_key => ENV["GEM_HOST_API_KEY"] }
+
+      mkdir_p File.dirname(Gem.configurations.credentials_path)
+      touch   Gem.configurations.credentials_path
+      chmod   0600, Gem.configurations.credentials_path
+
+      File.write Gem.configurations.credentials_path, creds.to_yaml
+    end
+  end
 end

--- a/rakelib/support/rubygems_helper.rb
+++ b/rakelib/support/rubygems_helper.rb
@@ -1,0 +1,12 @@
+module RubygemsHelper
+
+  module_function
+
+  # Run a `gem ...` command, but don't shell out to do it
+  def gem_run *args
+    require "rubygems/gem_runner"
+    require "rubygems/exceptions"
+
+    Gem::GemRunner.new.run args
+  end
+end


### PR DESCRIPTION
- Adds `git` tagging support to the Raketasks
- Refactors `rubygems` helper methods in to a shared module
- Adds push tasks for `rubygems_build.rake`
- Adds `github_build.rake` with push support (to github gem package repo)
- Adds `github.rake` for releasing to GitHub's release API (not the gem package repo)
- Adds global release tasks (for releasing to all three)