### PR TITLE
[templates/script.js.erb] Fix issue with zoom text

### DIFF
--- a/lib/flame_graph/templates/script.js.erb
+++ b/lib/flame_graph/templates/script.js.erb
@@ -81,7 +81,7 @@ function update_text(e) {
   var r = find_child(e, "rect");
   var t = find_child(e, "text");
   var w = parseFloat(r.attributes.width.value) -3;
-  var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+  var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)$/,"");
   t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
 
   // Smaller than this size won't fit anything


### PR DESCRIPTION
Was causing an extra `(` to be rendered when zooming/unzooming

Might be some other fixes, but this one is important.